### PR TITLE
Fix installation break

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -46,7 +46,7 @@ namespace :redmine do
         Backlogs.setting[:card_spec] = BacklogsPrintableCards::CardPageLayout.available[0]
       end
 
-      trackers = Tracker.find(:all)
+      trackers = Tracker.all
 
       if ENV['story_trackers'] && ENV['story_trackers'] != ''
         trackers =  ENV['story_trackers'].split(',')


### PR DESCRIPTION
This fixed the install break for me. Specifically: ActiveRecord::RecordNotFound: Couldn't find Tracker with 'id'=all

Also, install https://github.com/rails/activerecord-deprecated_finders to fix NoMethodError: undefined method `find_all_by_id' for #Class:0x00000004a3a648
